### PR TITLE
Don't assume std namespace

### DIFF
--- a/base/AlsaCtlPortConfig.cpp
+++ b/base/AlsaCtlPortConfig.cpp
@@ -31,13 +31,16 @@
 #include "MappingContext.h"
 #include "AlsaMappingKeys.hpp"
 #include <string.h>
+#include <string>
 #include <assert.h>
 #include <sstream>
 #include <limits>
 
+using std::string;
+
 #define base AlsaSubsystemObject
 
-const uint8_t AlsaCtlPortConfig::_tinyAlsaFormatInvalid = numeric_limits<uint8_t>::max();
+const uint8_t AlsaCtlPortConfig::_tinyAlsaFormatInvalid = std::numeric_limits<uint8_t>::max();
 
 AlsaCtlPortConfig::AlsaCtlPortConfig(const string &mappingValue,
                                      CInstanceConfigurableElement *instanceConfigurableElement,
@@ -144,7 +147,7 @@ string AlsaCtlPortConfig::formatAlsaError(StreamDirection streamDirection,
                                           const string &functionName,
                                           const string &error)
 {
-    ostringstream stringStream;
+    std::ostringstream stringStream;
 
     stringStream << (streamDirection ? "Capture" : "Playback") << " " <<
         functionName << " error: " << error;

--- a/base/AlsaCtlPortConfig.hpp
+++ b/base/AlsaCtlPortConfig.hpp
@@ -31,6 +31,7 @@
 
 #include "AlsaSubsystemObject.hpp"
 #include <stdint.h>
+#include <string>
 
 /**
  * Port configuration for alsa device class.
@@ -54,10 +55,10 @@ public:
     struct FormatTranslation
     {
         uint8_t formatAsNumerical; /**< Tiny alsa format value */
-        string formatAsString; /**< Litteral value */
+        std::string formatAsString; /**< Litteral value */
     };
 
-    AlsaCtlPortConfig(const string &mappingValue,
+    AlsaCtlPortConfig(const std::string &mappingValue,
                       CInstanceConfigurableElement *instanceConfigurableElement,
                       const CMappingContext &context,
                       const PortConfig &defaultPortConfig);
@@ -67,8 +68,8 @@ public:
 
 protected:
     // Sync to/from HW
-    virtual bool receiveFromHW(string &error);
-    virtual bool sendToHW(string &error);
+    virtual bool receiveFromHW(std::string &error);
+    virtual bool sendToHW(std::string &error);
 
     enum StreamDirection
     {
@@ -88,7 +89,7 @@ protected:
      *
      * @return true or false in case of failure
      */
-    virtual bool doOpenStream(StreamDirection streamDirection, string &error) = 0;
+    virtual bool doOpenStream(StreamDirection streamDirection, std::string &error) = 0;
 
     /**
      * Close a stream
@@ -121,9 +122,9 @@ protected:
      *
      * @return the string containing the error formatted
      */
-    string formatAlsaError(StreamDirection streamDirection,
-                           const string &functionName,
-                           const string &error);
+    std::string formatAlsaError(StreamDirection streamDirection,
+                           const std::string &functionName,
+                           const std::string &error);
 
 private:
     /**
@@ -134,7 +135,7 @@ private:
      *
      * @return true or false in case of failure
      */
-    bool updateStream(StreamDirection streamDirection, string &error);
+    bool updateStream(StreamDirection streamDirection, std::string &error);
 
     /**
      * Check if the stream is enabled.
@@ -154,7 +155,7 @@ private:
      *
      * @return success/failure
      */
-    bool openStream(StreamDirection streamDirection, string &error);
+    bool openStream(StreamDirection streamDirection, std::string &error);
 
     /**
      * Close the stream if needed.

--- a/base/AlsaSubsystemObject.cpp
+++ b/base/AlsaSubsystemObject.cpp
@@ -35,6 +35,9 @@
 #include <unistd.h>
 #include <errno.h>
 #include <string.h>
+#include <string>
+
+using std::string;
 
 #define base CFormattedSubsystemObject
 

--- a/base/AlsaSubsystemObject.hpp
+++ b/base/AlsaSubsystemObject.hpp
@@ -31,6 +31,7 @@
 
 #include "FormattedSubsystemObject.h"
 #include <stdint.h>
+#include <string>
 
 /**
  * Alsa subsystem object class.
@@ -39,10 +40,10 @@
 class AlsaSubsystemObject : public CFormattedSubsystemObject
 {
 public:
-    AlsaSubsystemObject(const string &mappingValue,
+    AlsaSubsystemObject(const std::string &mappingValue,
                         CInstanceConfigurableElement *instanceConfigurableElement,
                         const CMappingContext &context);
-    AlsaSubsystemObject(const string &strMappingValue,
+    AlsaSubsystemObject(const std::string &strMappingValue,
                         CInstanceConfigurableElement *instanceConfigurableElement,
                         uint32_t firstAmendKey,
                         uint32_t nbAmendKeys,
@@ -61,7 +62,7 @@ protected:
      *
      * @return the name of the alsa card
      */
-    const string &getCardName() const { return _cardName; }
+    const std::string &getCardName() const { return _cardName; }
 
 private:
     /**
@@ -71,12 +72,12 @@ private:
      *
      * @return the number of the corresponding alsa card
      */
-    static int getCardNumberByName(const string &cardName);
+    static int getCardNumberByName(const std::string &cardName);
 
     /** Path of the sound card in the file system */
     static const char _soundCardPath[];
     /** Card name to which the Alsa device belong */
-    string _cardName;
+    std::string _cardName;
     /** Card Index to which the Alsa device belong */
     int32_t _cardIndex;
 };

--- a/base/AmixerControl.cpp
+++ b/base/AmixerControl.cpp
@@ -37,12 +37,13 @@
 #include "AlsaMappingKeys.hpp"
 #include "AutoLog.h"
 #include <string.h>
+#include <string>
 #include <ctype.h>
 #include <algorithm>
 
 #define base AlsaSubsystemObject
 
-AmixerControl::AmixerControl(const string &mappingValue,
+AmixerControl::AmixerControl(const std::string &mappingValue,
                              CInstanceConfigurableElement *instanceConfigurableElement,
                              const CMappingContext &context)
     : base(mappingValue, instanceConfigurableElement,
@@ -95,7 +96,7 @@ AmixerControl::AmixerControl(const string &mappingValue,
     }
 }
 
-AmixerControl::AmixerControl(const string &mappingValue,
+AmixerControl::AmixerControl(const std::string &mappingValue,
                              CInstanceConfigurableElement *instanceConfigurableElement,
                              const CMappingContext &context, uint32_t scalarSize)
     : base(mappingValue, instanceConfigurableElement,
@@ -112,7 +113,7 @@ void AmixerControl::logControlInfo(bool receive) const
 {
     if (_isDebugEnabled) {
 
-        string controlName = getFormattedMappingValue();
+        std::string controlName = getFormattedMappingValue();
         log_info("%s ALSA Element Instance: %s\t\t(Control Element: %s)",
                  receive ? "Reading" : "Writing",
                  getConfigurableElement()->getPath().c_str(), controlName.c_str());

--- a/base/AmixerControl.hpp
+++ b/base/AmixerControl.hpp
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "AlsaSubsystemObject.hpp"
+#include <string>
 
 class CInstanceConfigurableElement;
 class CMappingContext;
@@ -49,7 +50,7 @@ public:
      * @param[in] instanceConfigurableElement pointer to configurable element instance
      * @param[in] context contains the context mappings
      */
-    AmixerControl(const string &mappingValue,
+    AmixerControl(const std::string &mappingValue,
                   CInstanceConfigurableElement *instanceConfigurableElement,
                   const CMappingContext &context);
 
@@ -61,12 +62,12 @@ public:
      * @param[in] context contains the context mappings
      * @param[in] scalarSize used to force scalarSize value
      */
-    AmixerControl(const string &mappingValue,
+    AmixerControl(const std::string &mappingValue,
                   CInstanceConfigurableElement *instanceConfigurableElement,
                   const CMappingContext &context, uint32_t scalarSize);
 
 protected:
-    virtual bool accessHW(bool receive, string &error) = 0;
+    virtual bool accessHW(bool receive, std::string &error) = 0;
 
     /**
      * Logging Control Info
@@ -82,7 +83,7 @@ protected:
      *
      * @return the name of the control
      */
-    const string getControlName() const { return getFormattedMappingValue(); }
+    const std::string getControlName() const { return getFormattedMappingValue(); }
 
     /**
      * Get the parameter scalar size for elementary access

--- a/base/AmixerMutableVolume.hpp
+++ b/base/AmixerMutableVolume.hpp
@@ -72,7 +72,7 @@ public:
      * @param[in] instConfigElement pointer to configurable element instance
      * @param[in] context contains the context mappings
      */
-    AmixerMutableVolume(const string &mappingValue,
+    AmixerMutableVolume(const std::string &mappingValue,
                         CInstanceConfigurableElement *instConfigElement,
                         const CMappingContext &context)
         : SubsystemObjectBase(mappingValue, instConfigElement, context),

--- a/legacy/LegacyAlsaCtlPortConfig.cpp
+++ b/legacy/LegacyAlsaCtlPortConfig.cpp
@@ -31,6 +31,7 @@
 #include "MappingContext.h"
 #include "AlsaMappingKeys.hpp"
 #include <string.h>
+#include <string>
 #include <alsa/asoundlib.h>
 #include <sstream>
 
@@ -46,7 +47,7 @@ const AlsaCtlPortConfig::PortConfig LegacyAlsaCtlPortConfig::_defaultPortConfig 
 const uint32_t LegacyAlsaCtlPortConfig::_latencyMicroSeconds = 500000;
 
 LegacyAlsaCtlPortConfig::LegacyAlsaCtlPortConfig(
-    const string &mappingValue,
+    const std::string &mappingValue,
     CInstanceConfigurableElement *instanceConfigurableElement,
     const CMappingContext &context)
     :  base(mappingValue, instanceConfigurableElement, context, _defaultPortConfig)
@@ -56,10 +57,10 @@ LegacyAlsaCtlPortConfig::LegacyAlsaCtlPortConfig(
     _streamHandle[Capture] = NULL;
 
     // Retrieve card index
-    string cardIndex = context.getItem(AlsaCard);
+    std::string cardIndex = context.getItem(AlsaCard);
 
     // Create device name
-    ostringstream streamName;
+    std::ostringstream streamName;
 
     streamName << "hw:" << snd_card_get_index(cardIndex.c_str())
                << "," << context.getItem(AlsaCtlDevice);
@@ -68,7 +69,7 @@ LegacyAlsaCtlPortConfig::LegacyAlsaCtlPortConfig(
 
 }
 
-bool LegacyAlsaCtlPortConfig::doOpenStream(StreamDirection streamDirection, string &error)
+bool LegacyAlsaCtlPortConfig::doOpenStream(StreamDirection streamDirection, std::string &error)
 {
     snd_pcm_t *&streamHandle = _streamHandle[streamDirection];
     int32_t errorId;

--- a/legacy/LegacyAlsaCtlPortConfig.hpp
+++ b/legacy/LegacyAlsaCtlPortConfig.hpp
@@ -31,6 +31,7 @@
 
 #include "AlsaCtlPortConfig.hpp"
 #include <stdint.h>
+#include <string>
 
 struct _snd_pcm;
 
@@ -44,13 +45,13 @@ public:
      * @param[in] instanceConfigurableElement pointer to configurable element instance
      * @param[in] context contains the context mappings
      */
-    LegacyAlsaCtlPortConfig(const string &mappingValue,
+    LegacyAlsaCtlPortConfig(const std::string &mappingValue,
                             CInstanceConfigurableElement *instanceConfigurableElement,
                             const CMappingContext &context);
 
 protected:
     // Stream operations
-    virtual bool doOpenStream(StreamDirection streamDirection, string &error);
+    virtual bool doOpenStream(StreamDirection streamDirection, std::string &error);
     virtual void doCloseStream(StreamDirection streamDirection);
 
 private:
@@ -59,7 +60,7 @@ private:
     /** Latency */
     static const uint32_t _latencyMicroSeconds;
     /** Stream Name */
-    string _streamName;
+    std::string _streamName;
 
     /**
      * Stream handles.

--- a/legacy/LegacyAlsaSubsystem.cpp
+++ b/legacy/LegacyAlsaSubsystem.cpp
@@ -34,8 +34,9 @@
 #include "SubsystemObjectFactory.h"
 #include "AlsaMappingKeys.hpp"
 #include "AmixerMutableVolume.hpp"
+#include <string>
 
-LegacyAlsaSubsystem::LegacyAlsaSubsystem(const string &name) : AlsaSubsystem(name)
+LegacyAlsaSubsystem::LegacyAlsaSubsystem(const std::string &name) : AlsaSubsystem(name)
 {
     // Provide creators to upper layer
     addSubsystemObjectFactory(

--- a/legacy/LegacyAlsaSubsystem.hpp
+++ b/legacy/LegacyAlsaSubsystem.hpp
@@ -31,9 +31,10 @@
 #pragma once
 
 #include "AlsaSubsystem.hpp"
+#include <string>
 
 class LegacyAlsaSubsystem : public AlsaSubsystem
 {
 public:
-    LegacyAlsaSubsystem(const string &name);
+    LegacyAlsaSubsystem(const std::string &name);
 };

--- a/legacy/LegacyAmixerControl.cpp
+++ b/legacy/LegacyAmixerControl.cpp
@@ -36,6 +36,7 @@
 #include "AutoLog.h"
 #include <assert.h>
 #include <string.h>
+#include <string>
 #include <errno.h>
 #include <ctype.h>
 #include <alsa/asoundlib.h>
@@ -52,7 +53,7 @@ int snd_ctl_hw_open(snd_ctl_t **handle, const char *name, int card, int mode);
 #define base AmixerControl
 
 LegacyAmixerControl::LegacyAmixerControl(
-    const string &mappingValue,
+    const std::string &mappingValue,
     CInstanceConfigurableElement *instanceConfigurableElement,
     const CMappingContext &context)
     : base(mappingValue, instanceConfigurableElement, context)
@@ -60,7 +61,7 @@ LegacyAmixerControl::LegacyAmixerControl(
 
 }
 
-bool LegacyAmixerControl::accessHW(bool receive, string &error)
+bool LegacyAmixerControl::accessHW(bool receive, std::string &error)
 {
     CAutoLog autoLog(getConfigurableElement(), "ALSA", isDebugEnabled());
 
@@ -114,7 +115,7 @@ bool LegacyAmixerControl::accessHW(bool receive, string &error)
     }
 #else
     // Create device name
-    ostringstream deviceName;
+    std::ostringstream deviceName;
 
     deviceName << "hw:" << cardNumber;
 
@@ -135,7 +136,7 @@ bool LegacyAmixerControl::accessHW(bool receive, string &error)
     // Set interface
     snd_ctl_elem_id_set_interface(id, SND_CTL_ELEM_IFACE_MIXER);
 
-    string controlName = getControlName();
+    std::string controlName = getControlName();
 
     // Set name or id
     if (isdigit(controlName[0])) {

--- a/legacy/LegacyAmixerControl.hpp
+++ b/legacy/LegacyAmixerControl.hpp
@@ -31,6 +31,7 @@
 
 #include "AmixerControl.hpp"
 #include <stdint.h>
+#include <string>
 
 class LegacyAmixerControl : public AmixerControl
 {
@@ -42,10 +43,10 @@ public:
      * @param[in] instanceConfigurableElement pointer to configurable element instance
      * @param[in] context contains the context mappings
      */
-    LegacyAmixerControl(const string &mappingValue,
+    LegacyAmixerControl(const std::string &mappingValue,
                         CInstanceConfigurableElement *instanceConfigurableElement,
                         const CMappingContext &context);
 
 protected:
-    virtual bool accessHW(bool receive, string &error);
+    virtual bool accessHW(bool receive, std::string &error);
 };

--- a/tinyalsa/TinyAlsaCtlPortConfig.cpp
+++ b/tinyalsa/TinyAlsaCtlPortConfig.cpp
@@ -31,8 +31,8 @@
 #include "MappingContext.h"
 #include "AlsaMappingKeys.hpp"
 
-#include <string.h>
 #include <tinyalsa/asoundlib.h>
+#include <string>
 #include <sstream>
 
 #define base AlsaCtlPortConfig
@@ -67,7 +67,7 @@ const AlsaCtlPortConfig::PortConfig TinyAlsaCtlPortConfig::_defaultPortConfig = 
 };
 
 TinyAlsaCtlPortConfig::TinyAlsaCtlPortConfig(
-    const string &mappingValue,
+    const std::string &mappingValue,
     CInstanceConfigurableElement *instanceConfigurableElement,
     const CMappingContext &context)
     : base(mappingValue, instanceConfigurableElement, context, _defaultPortConfig)
@@ -77,7 +77,7 @@ TinyAlsaCtlPortConfig::TinyAlsaCtlPortConfig(
     _streamHandle[Capture] = NULL;
 }
 
-bool TinyAlsaCtlPortConfig::doOpenStream(StreamDirection streamDirection, string &error)
+bool TinyAlsaCtlPortConfig::doOpenStream(StreamDirection streamDirection, std::string &error)
 {
     struct pcm *&streamHandle = _streamHandle[streamDirection];
     struct pcm_config pcmConfig;

--- a/tinyalsa/TinyAlsaCtlPortConfig.hpp
+++ b/tinyalsa/TinyAlsaCtlPortConfig.hpp
@@ -45,13 +45,13 @@ public:
      * @param[in] instanceConfigurableElement pointer to configurable element instance
      * @param[in] context contains the context mappings
      */
-    TinyAlsaCtlPortConfig(const string &mappingValue,
+    TinyAlsaCtlPortConfig(const std::string &mappingValue,
                           CInstanceConfigurableElement *instanceConfigurableElement,
                           const CMappingContext &context);
 
 protected:
     // Stream operations
-    virtual bool doOpenStream(StreamDirection streamDirection, string &error);
+    virtual bool doOpenStream(StreamDirection streamDirection, std::string &error);
     virtual void doCloseStream(StreamDirection streamDirection);
 
 private:

--- a/tinyalsa/TinyAlsaSubsystem.cpp
+++ b/tinyalsa/TinyAlsaSubsystem.cpp
@@ -35,8 +35,9 @@
 #include "SubsystemObjectFactory.h"
 #include "AlsaMappingKeys.hpp"
 #include "AmixerMutableVolume.hpp"
+#include <string>
 
-TinyAlsaSubsystem::TinyAlsaSubsystem(const string &name) : AlsaSubsystem(name), mMixers()
+TinyAlsaSubsystem::TinyAlsaSubsystem(const std::string &name) : AlsaSubsystem(name), mMixers()
 {
     // Provide creators to upper layer
     addSubsystemObjectFactory(

--- a/tinyalsa/TinyAlsaSubsystem.hpp
+++ b/tinyalsa/TinyAlsaSubsystem.hpp
@@ -31,13 +31,14 @@
 #pragma once
 
 #include "AlsaSubsystem.hpp"
+#include <string>
 #include <map>
 #include <tinyalsa/asoundlib.h>
 
 class TinyAlsaSubsystem : public AlsaSubsystem
 {
 public:
-    TinyAlsaSubsystem(const string &name);
+    TinyAlsaSubsystem(const std::string &name);
     ~TinyAlsaSubsystem();
 
     /**

--- a/tinyalsa/TinyAmixerControl.cpp
+++ b/tinyalsa/TinyAmixerControl.cpp
@@ -33,6 +33,7 @@
 #include "MappingContext.h"
 #include "AutoLog.h"
 #include <tinyalsa/asoundlib.h>
+#include <string>
 #include <string.h>
 #include <ctype.h>
 #include <errno.h>
@@ -44,7 +45,7 @@ extern "C" void __gcov_flush();
 
 #define base AmixerControl
 
-TinyAmixerControl::TinyAmixerControl(const string &mappingValue,
+TinyAmixerControl::TinyAmixerControl(const std::string &mappingValue,
                                      CInstanceConfigurableElement *instanceConfigurableElement,
                                      const CMappingContext &context)
     : base(mappingValue, instanceConfigurableElement, context)
@@ -54,7 +55,7 @@ TinyAmixerControl::TinyAmixerControl(const string &mappingValue,
 #endif // __USE_GCOV__
 }
 
-TinyAmixerControl::TinyAmixerControl(const string &mappingValue,
+TinyAmixerControl::TinyAmixerControl(const std::string &mappingValue,
                                      CInstanceConfigurableElement *instanceConfigurableElement,
                                      const CMappingContext &context, uint32_t scalarSize)
     : base(mappingValue, instanceConfigurableElement, context, scalarSize)
@@ -66,7 +67,7 @@ uint32_t TinyAmixerControl::getNumValues(struct mixer_ctl *mixerControl)
     return mixer_ctl_get_num_values(mixerControl);
 }
 
-bool TinyAmixerControl::accessHW(bool receive, string &error)
+bool TinyAmixerControl::accessHW(bool receive, std::string &error)
 {
     CAutoLog autoLog(getConfigurableElement(), "ALSA", isDebugEnabled());
 
@@ -75,7 +76,7 @@ bool TinyAmixerControl::accessHW(bool receive, string &error)
     // Mixer control handle
     struct mixer_ctl *mixerControl;
     uint32_t elementCount;
-    string controlName = getControlName();
+    std::string controlName = getControlName();
 
     // Debug conditionnaly enabled in XML
     logControlInfo(receive);

--- a/tinyalsa/TinyAmixerControl.hpp
+++ b/tinyalsa/TinyAmixerControl.hpp
@@ -46,7 +46,7 @@ public:
      * @param[in] instanceConfigurableElement pointer to configurable element instance
      * @param[in] context contains the context mappings
      */
-    TinyAmixerControl(const string &mappingValue,
+    TinyAmixerControl(const std::string &mappingValue,
                       CInstanceConfigurableElement *instanceConfigurableElement,
                       const CMappingContext &context);
 
@@ -58,13 +58,13 @@ public:
      * @param[in] context contains the context mappings
      * @param[in] scalarSize used to force scalarSize value
      */
-    TinyAmixerControl(const string &mappingValue,
+    TinyAmixerControl(const std::string &mappingValue,
                       CInstanceConfigurableElement *instanceConfigurableElement,
                       const CMappingContext &context,
                       uint32_t scalarSize);
 
 protected:
-    virtual bool accessHW(bool receive, string &error);
+    virtual bool accessHW(bool receive, std::string &error);
 
     /**
      * Get the number of values in a mixer control
@@ -86,7 +86,7 @@ protected:
      */
     virtual bool readControl(struct mixer_ctl *mixerControl,
                              uint32_t elementCount,
-                             string &error) = 0;
+                             std::string &error) = 0;
 
     /**
      * Writes the value(s) of an alsa mixer
@@ -99,5 +99,5 @@ protected:
      */
     virtual bool writeControl(struct mixer_ctl *mixerControl,
                               uint32_t elementCount,
-                              string &error) = 0;
+                              std::string &error) = 0;
 };

--- a/tinyalsa/TinyAmixerControlArray.cpp
+++ b/tinyalsa/TinyAmixerControlArray.cpp
@@ -33,6 +33,7 @@
 #include <tinyalsa/asoundlib.h>
 #include <errno.h>
 #include <string.h>
+#include <string>
 #include <sstream>
 
 #define base TinyAmixerControl
@@ -40,7 +41,7 @@
 #define maxLogLine 64
 
 TinyAmixerControlArray::TinyAmixerControlArray(
-    const string &mappingValue,
+    const std::string &mappingValue,
     CInstanceConfigurableElement *instanceConfigurableElement,
     const CMappingContext &context)
     : base(mappingValue, instanceConfigurableElement, context, _byteScalarSize)
@@ -83,7 +84,7 @@ int TinyAmixerControlArray::setArrayMixer(struct mixer_ctl *mixerControl, uint32
 
 bool TinyAmixerControlArray::readControl(struct mixer_ctl *mixerControl,
                                          uint32_t elementCount,
-                                         string &error)
+                                         std::string &error)
 {
     int err;
 
@@ -99,7 +100,7 @@ bool TinyAmixerControlArray::readControl(struct mixer_ctl *mixerControl,
 
 bool TinyAmixerControlArray::writeControl(struct mixer_ctl *mixerControl,
                                           uint32_t elementCount,
-                                          string &error)
+                                          std::string &error)
 {
     int err;
 
@@ -136,7 +137,7 @@ void TinyAmixerControlArray::logControlValues(bool receive,
         log.fill('0');
         // cast to uint16_t necessary in order to avoid 'buffer[idx]' to be
         // treated as a printable character, apparently
-        log << hex << static_cast<unsigned short>(buffer[idx]) << " ";
+        log << std::hex << static_cast<unsigned short>(buffer[idx]) << " ";
         if ((idx != 0) && ((idx % maxLogLine) == 0)) {
             log << '\n';
             displayAndCleanString(log);
@@ -148,6 +149,6 @@ void TinyAmixerControlArray::logControlValues(bool receive,
         displayAndCleanString(log);
     }
 
-    log << "[" << dec << elementCount << " bytes]" << endl;
+    log << "[" << std::dec << elementCount << " bytes]" << std::endl;
     displayAndCleanString(log);
 }

--- a/tinyalsa/TinyAmixerControlArray.hpp
+++ b/tinyalsa/TinyAmixerControlArray.hpp
@@ -45,18 +45,18 @@ public:
      * @param[in] instanceConfigurableElement pointer to configurable element instance
      * @param[in] context contains the context mappings
      */
-    TinyAmixerControlArray(const string &mappingValue,
+    TinyAmixerControlArray(const std::string &mappingValue,
                            CInstanceConfigurableElement *instanceConfigurableElement,
                            const CMappingContext &context);
 
 protected:
     virtual bool readControl(struct mixer_ctl *mixerControl,
                              uint32_t elementCount,
-                             string &error);
+                             std::string &error);
 
     virtual bool writeControl(struct mixer_ctl *mixerControl,
                               uint32_t elementCount,
-                              string &error);
+                              std::string &error);
 
     /**
      * Derivable method for storing alsa ByteControls into blackboard

--- a/tinyalsa/TinyAmixerControlValue.cpp
+++ b/tinyalsa/TinyAmixerControlValue.cpp
@@ -34,11 +34,12 @@
 #include <string.h>
 #include <ctype.h>
 #include <errno.h>
+#include <string>
 
 #define base TinyAmixerControl
 
 TinyAmixerControlValue::TinyAmixerControlValue(
-    const string &mappingValue,
+    const std::string &mappingValue,
     CInstanceConfigurableElement *instanceConfigurableElement,
     const CMappingContext &context)
     : base(mappingValue, instanceConfigurableElement, context)
@@ -47,7 +48,7 @@ TinyAmixerControlValue::TinyAmixerControlValue(
 
 bool TinyAmixerControlValue::readControl(struct mixer_ctl *mixerControl,
                                          uint32_t elementCount,
-                                         string &error)
+                                         std::string &error)
 {
     uint32_t elementNumber;
 
@@ -75,7 +76,7 @@ bool TinyAmixerControlValue::readControl(struct mixer_ctl *mixerControl,
 
 bool TinyAmixerControlValue::writeControl(struct mixer_ctl *mixerControl,
                                           uint32_t elementCount,
-                                          string &error)
+                                          std::string &error)
 {
     uint32_t elementNumber;
 

--- a/tinyalsa/TinyAmixerControlValue.hpp
+++ b/tinyalsa/TinyAmixerControlValue.hpp
@@ -45,16 +45,16 @@ public:
      * @param[in] instanceConfigurableElement pointer to configurable element instance
      * @param[in] context contains the context mappings
      */
-    TinyAmixerControlValue(const string &mappingValue,
+    TinyAmixerControlValue(const std::string &mappingValue,
                            CInstanceConfigurableElement *instanceConfigurableElement,
                            const CMappingContext &context);
 
 protected:
     virtual bool readControl(struct mixer_ctl *mixerControl,
                              uint32_t elementCount,
-                             string &error);
+                             std::string &error);
 
     virtual bool writeControl(struct mixer_ctl *mixerControl,
                               uint32_t elementCount,
-                              string &error);
+                              std::string &error);
 };


### PR DESCRIPTION
The PFW core headers have been reworked to remove all occurences of "using
namespace std", which is regarded as bad practice leading to namespace
poisoning.

The filesystem plugin needs to be updated accordingly.

Change-Id: I5077b1f60b3a8b773031ba8a0c9ae924be8ffdd9
Signed-off-by: David Wagner david.wagner@intel.com
