### PR TITLE
Use standard library path for pfw plugin location

### DIFF
--- a/legacy/Android.mk
+++ b/legacy/Android.mk
@@ -63,7 +63,6 @@ LOCAL_CFLAGS += \
     -Wextra \
     -Wno-unused-parameter    # Needed to workaround STL bug
 
-LOCAL_MODULE_PATH := $(TARGET_OUT_SHARED_LIBRARIES)/parameter-framework-plugins/Audio
 LOCAL_MODULE := libalsa-subsystem
 LOCAL_MODULE_TAGS := optional
 

--- a/tinyalsa/Android.mk
+++ b/tinyalsa/Android.mk
@@ -60,7 +60,6 @@ LOCAL_CFLAGS += \
     -Wno-unused-parameter    # Needed to workaround STL bug
 
 LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)
-LOCAL_MODULE_PATH := $(TARGET_OUT_SHARED_LIBRARIES)/parameter-framework-plugins/Audio
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE := libtinyalsa-subsystem
 


### PR DESCRIPTION
This pull request is about the plugin's installation directory on an Android target.

With this patch, the plugin is installed in the standard shared library directory, instead of in a custom location
