### PR TITLE
Android.mk: declare intel as module owner

### DIFF
--- a/base/Android.mk
+++ b/base/Android.mk
@@ -51,6 +51,7 @@ LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)
 LOCAL_MODULE_PATH := $(TARGET_OUT_SHARED_LIBRARIES)/parameter-framework-plugins/Audio
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE := libalsabase-subsystem
+LOCAL_MODULE_OWNER := intel
 
 include external/stlport/libstlport.mk
 include $(BUILD_STATIC_LIBRARY)

--- a/legacy/Android.mk
+++ b/legacy/Android.mk
@@ -65,6 +65,7 @@ LOCAL_CFLAGS += \
 
 LOCAL_MODULE_PATH := $(TARGET_OUT_SHARED_LIBRARIES)/parameter-framework-plugins/Audio
 LOCAL_MODULE := libalsa-subsystem
+LOCAL_MODULE_OWNER := intel
 LOCAL_MODULE_TAGS := optional
 
 include external/stlport/libstlport.mk

--- a/tinyalsa/Android.mk
+++ b/tinyalsa/Android.mk
@@ -63,6 +63,7 @@ LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)
 LOCAL_MODULE_PATH := $(TARGET_OUT_SHARED_LIBRARIES)/parameter-framework-plugins/Audio
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE := libtinyalsa-subsystem
+LOCAL_MODULE_OWNER := intel
 
 include external/stlport/libstlport.mk
 include $(BUILD_SHARED_LIBRARY)


### PR DESCRIPTION
This is mandatory for our internal usages.
