### PR TITLE
Clang compilation

### DIFF
--- a/base/AlsaCtlPortConfig.cpp
+++ b/base/AlsaCtlPortConfig.cpp
@@ -43,10 +43,12 @@ using std::string;
 AlsaCtlPortConfig::AlsaCtlPortConfig(const string &mappingValue,
                                      CInstanceConfigurableElement *instanceConfigurableElement,
                                      const CMappingContext &context,
+                                     core::log::ILogger& logger,
                                      const PortConfig &defaultPortConfig)
     : base(mappingValue,
            instanceConfigurableElement,
-           context),
+           context,
+           logger),
       _device(context.getItemAsInteger(AlsaCtlDevice)),
       _portConfig(defaultPortConfig)
 {

--- a/base/AlsaCtlPortConfig.hpp
+++ b/base/AlsaCtlPortConfig.hpp
@@ -60,7 +60,8 @@ public:
 
     AlsaCtlPortConfig(const std::string &mappingValue,
                       CInstanceConfigurableElement *instanceConfigurableElement,
-                      const CMappingContext &context,
+                      const CMappingContext &contVext,
+                      core::log::ILogger& logger,
                       const PortConfig &defaultPortConfig);
 
 protected:

--- a/base/AlsaSubsystem.hpp
+++ b/base/AlsaSubsystem.hpp
@@ -41,7 +41,7 @@
 class AlsaSubsystem : public CSubsystem
 {
 public:
-    AlsaSubsystem(const std::string &name) : CSubsystem(name)
+    AlsaSubsystem(const std::string &name, core::log::ILogger& logger) : CSubsystem(name, logger)
     {
         // Provide mapping keys to upper layer
         addContextMappingKey("Card");

--- a/base/AlsaSubsystemObject.cpp
+++ b/base/AlsaSubsystemObject.cpp
@@ -45,8 +45,9 @@ const char AlsaSubsystemObject::_soundCardPath[] = "/proc/asound/";
 
 AlsaSubsystemObject::AlsaSubsystemObject(const string &mappingValue,
                                          CInstanceConfigurableElement *instanceConfigurableElement,
-                                         const CMappingContext &context)
-    : base(instanceConfigurableElement, mappingValue),
+                                         const CMappingContext &context,
+                                         core::log::ILogger& logger)
+    : base(instanceConfigurableElement, logger, mappingValue),
       _cardName(context.getItem(AlsaCard)),
       _cardIndex(getCardNumberByName(context.getItem(AlsaCard)))
 {
@@ -55,10 +56,11 @@ AlsaSubsystemObject::AlsaSubsystemObject(const string &mappingValue,
 
 AlsaSubsystemObject::AlsaSubsystemObject(const string &mappingValue,
                                          CInstanceConfigurableElement *instanceConfigurableElement,
+                                         core::log::ILogger& logger,
                                          uint32_t firstAmendKey,
                                          uint32_t nbAmendKeys,
                                          const CMappingContext &context)
-    : base(instanceConfigurableElement, mappingValue, firstAmendKey, nbAmendKeys, context),
+    : base(instanceConfigurableElement, logger, mappingValue, firstAmendKey, nbAmendKeys, context),
       _cardName(context.getItem(AlsaCard)),
       _cardIndex(getCardNumberByName(context.getItem(AlsaCard)))
 {

--- a/base/AlsaSubsystemObject.hpp
+++ b/base/AlsaSubsystemObject.hpp
@@ -42,9 +42,11 @@ class AlsaSubsystemObject : public CFormattedSubsystemObject
 public:
     AlsaSubsystemObject(const std::string &mappingValue,
                         CInstanceConfigurableElement *instanceConfigurableElement,
-                        const CMappingContext &context);
+                        const CMappingContext &context,
+                        core::log::ILogger& logger);
     AlsaSubsystemObject(const std::string &strMappingValue,
                         CInstanceConfigurableElement *instanceConfigurableElement,
+                        core::log::ILogger& logger,
                         uint32_t firstAmendKey,
                         uint32_t nbAmendKeys,
                         const CMappingContext &context);

--- a/base/AmixerControl.cpp
+++ b/base/AmixerControl.cpp
@@ -35,7 +35,6 @@
 #include "ParameterBlockType.h"
 #include "MappingContext.h"
 #include "AlsaMappingKeys.hpp"
-#include "AutoLog.h"
 #include <string.h>
 #include <string>
 #include <ctype.h>
@@ -45,8 +44,9 @@
 
 AmixerControl::AmixerControl(const std::string &mappingValue,
                              CInstanceConfigurableElement *instanceConfigurableElement,
-                             const CMappingContext &context)
-    : base(mappingValue, instanceConfigurableElement,
+                             const CMappingContext &context,
+                             core::log::ILogger& logger)
+    : base(mappingValue, instanceConfigurableElement, logger,
            AlsaAmend1,
            gNbAlsaAmends,
            context),
@@ -98,8 +98,10 @@ AmixerControl::AmixerControl(const std::string &mappingValue,
 
 AmixerControl::AmixerControl(const std::string &mappingValue,
                              CInstanceConfigurableElement *instanceConfigurableElement,
-                             const CMappingContext &context, uint32_t scalarSize)
-    : base(mappingValue, instanceConfigurableElement,
+                             const CMappingContext &context,
+                             core::log::ILogger& logger,
+                             uint32_t scalarSize)
+    : base(mappingValue, instanceConfigurableElement, logger,
            AlsaAmend1,
            gNbAlsaAmends,
            context),
@@ -114,9 +116,9 @@ void AmixerControl::logControlInfo(bool receive) const
     if (_isDebugEnabled) {
 
         std::string controlName = getFormattedMappingValue();
-        log_info("%s ALSA Element Instance: %s\t\t(Control Element: %s)",
-                 receive ? "Reading" : "Writing",
-                 getConfigurableElement()->getPath().c_str(), controlName.c_str());
+        std::string way = (receive ? "Reading" : "Writing");
+        _Logger.info( way + " ALSA Element Instance: " + getConfigurableElement()->getPath() +
+                     "\t\t(Control Element: " + controlName + ")");
     }
 }
 

--- a/base/AmixerControl.hpp
+++ b/base/AmixerControl.hpp
@@ -52,7 +52,8 @@ public:
      */
     AmixerControl(const std::string &mappingValue,
                   CInstanceConfigurableElement *instanceConfigurableElement,
-                  const CMappingContext &context);
+                  const CMappingContext &context,
+                  core::log::ILogger& logger);
 
     /**
      * AmixerControl Class constructor
@@ -64,7 +65,9 @@ public:
      */
     AmixerControl(const std::string &mappingValue,
                   CInstanceConfigurableElement *instanceConfigurableElement,
-                  const CMappingContext &context, uint32_t scalarSize);
+                  const CMappingContext &context,
+                  core::log::ILogger& logger,
+                  uint32_t scalarSize);
 
 protected:
     virtual bool accessHW(bool receive, std::string &error) = 0;

--- a/base/AmixerMutableVolume.hpp
+++ b/base/AmixerMutableVolume.hpp
@@ -74,8 +74,9 @@ public:
      */
     AmixerMutableVolume(const std::string &mappingValue,
                         CInstanceConfigurableElement *instConfigElement,
-                        const CMappingContext &context)
-        : SubsystemObjectBase(mappingValue, instConfigElement, context),
+                        const CMappingContext &context,
+                        core::log::ILogger& logger)
+        : SubsystemObjectBase(mappingValue, instConfigElement, context, logger),
           _volumeLevelConfigurableElement(NULL)
     {
         if ((instConfigElement->getType() == CInstanceConfigurableElement::EParameterBlock) &&

--- a/base/Android.mk
+++ b/base/Android.mk
@@ -52,5 +52,6 @@ LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE := libalsabase-subsystem
 LOCAL_MODULE_OWNER := intel
 
-include external/stlport/libstlport.mk
+LOCAL_CLANG := true
+include external/libcxx/libcxx.mk
 include $(BUILD_STATIC_LIBRARY)

--- a/legacy/Android.mk
+++ b/legacy/Android.mk
@@ -67,7 +67,8 @@ LOCAL_MODULE := libalsa-subsystem
 LOCAL_MODULE_OWNER := intel
 LOCAL_MODULE_TAGS := optional
 
-include external/stlport/libstlport.mk
+LOCAL_CLANG := true
+include external/libcxx/libcxx.mk
 include $(BUILD_SHARED_LIBRARY)
 
 endif # $(PFW_LEGACY_ALSA)

--- a/legacy/LegacyAlsaCtlPortConfig.cpp
+++ b/legacy/LegacyAlsaCtlPortConfig.cpp
@@ -49,8 +49,9 @@ const uint32_t LegacyAlsaCtlPortConfig::_latencyMicroSeconds = 500000;
 LegacyAlsaCtlPortConfig::LegacyAlsaCtlPortConfig(
     const std::string &mappingValue,
     CInstanceConfigurableElement *instanceConfigurableElement,
-    const CMappingContext &context)
-    :  base(mappingValue, instanceConfigurableElement, context, _defaultPortConfig)
+    const CMappingContext &context,
+    core::log::ILogger& logger)
+    :  base(mappingValue, instanceConfigurableElement, context, logger, _defaultPortConfig)
 {
     // Init stream handle array
     _streamHandle[Playback] = NULL;

--- a/legacy/LegacyAlsaCtlPortConfig.hpp
+++ b/legacy/LegacyAlsaCtlPortConfig.hpp
@@ -47,7 +47,8 @@ public:
      */
     LegacyAlsaCtlPortConfig(const std::string &mappingValue,
                             CInstanceConfigurableElement *instanceConfigurableElement,
-                            const CMappingContext &context);
+                            const CMappingContext &context,
+                            core::log::ILogger& logger);
 
 protected:
     // Stream operations

--- a/legacy/LegacyAlsaSubsystem.cpp
+++ b/legacy/LegacyAlsaSubsystem.cpp
@@ -36,7 +36,8 @@
 #include "AmixerMutableVolume.hpp"
 #include <string>
 
-LegacyAlsaSubsystem::LegacyAlsaSubsystem(const std::string &name) : AlsaSubsystem(name)
+LegacyAlsaSubsystem::LegacyAlsaSubsystem(const std::string &name, core::log::ILogger& logger) :
+    AlsaSubsystem(name, logger)
 {
     // Provide creators to upper layer
     addSubsystemObjectFactory(

--- a/legacy/LegacyAlsaSubsystem.hpp
+++ b/legacy/LegacyAlsaSubsystem.hpp
@@ -36,5 +36,5 @@
 class LegacyAlsaSubsystem : public AlsaSubsystem
 {
 public:
-    LegacyAlsaSubsystem(const std::string &name);
+    LegacyAlsaSubsystem(const std::string &name, core::log::ILogger& logger);
 };

--- a/legacy/LegacyAlsaSubsystemBuilder.cpp
+++ b/legacy/LegacyAlsaSubsystemBuilder.cpp
@@ -28,7 +28,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "SubsystemLibrary.h"
-#include "NamedElementBuilderTemplate.h"
+#include "LoggingElementBuilderTemplate.h"
 #include "LegacyAlsaSubsystem.hpp"
 #include "LegacyAmixerControl.hpp"
 
@@ -44,7 +44,8 @@ extern "C"
 void getALSASubsystemBuilder(CSubsystemLibrary *subsystemLibrary)
 {
     subsystemLibrary->addElementBuilder(
-        "ALSA", new TNamedElementBuilderTemplate<LegacyAlsaSubsystem>
+        "ALSA", new TLoggingElementBuilderTemplate<LegacyAlsaSubsystem>(
+            subsystemLibrary->getLogger())
         );
 }
 }

--- a/legacy/LegacyAmixerControl.cpp
+++ b/legacy/LegacyAmixerControl.cpp
@@ -33,7 +33,6 @@
 #include "BitParameterBlockType.h"
 #include "MappingContext.h"
 #include "AlsaMappingKeys.hpp"
-#include "AutoLog.h"
 #include <assert.h>
 #include <string.h>
 #include <string>
@@ -55,25 +54,21 @@ int snd_ctl_hw_open(snd_ctl_t **handle, const char *name, int card, int mode);
 LegacyAmixerControl::LegacyAmixerControl(
     const std::string &mappingValue,
     CInstanceConfigurableElement *instanceConfigurableElement,
-    const CMappingContext &context)
-    : base(mappingValue, instanceConfigurableElement, context)
+    const CMappingContext &context,
+    core::log::ILogger& logger)
+    : base(mappingValue, instanceConfigurableElement, context, logger)
 {
 
 }
 
 bool LegacyAmixerControl::accessHW(bool receive, std::string &error)
 {
-    CAutoLog autoLog(getConfigurableElement(), "ALSA", isDebugEnabled());
-
 #ifdef SIMULATION
     if (receive) {
 
         memset(getBlackboardLocation(), 0, getSize());
     }
-    log_info("%s ALSA Element Instance: %s\t\t(Control Element: %s)",
-             receive ? "Reading" : "Writing",
-             getConfigurableElement()->getPath().c_str(),
-             getControlName().c_str());
+    base::logControlInfo(receive);
 
     return true;
 #endif
@@ -223,8 +218,10 @@ bool LegacyAmixerControl::accessHW(bool receive, std::string &error)
 
             if (isDebugEnabled()) {
 
-                log_info("Reading alsa element %s, index %u with value %u",
-                         controlName.c_str(), index, value);
+                std::ostringstream log;
+                log << "Writing alsa element " << controlName << ", index " << index
+                    << " with value " << value;
+                _Logger.info(log.str());
             }
 
             // Write data to blackboard (beware this code is OK on Little Endian machines only)
@@ -241,8 +238,10 @@ bool LegacyAmixerControl::accessHW(bool receive, std::string &error)
 
             if (isDebugEnabled()) {
 
-                log_info("Writing alsa element %s, index %u with value %u",
-                         controlName.c_str(), index, value);
+                std::ostringstream log;
+                log << "Writing alsa element " << controlName << ", index " << index
+                    << " with value " << value;
+                _Logger.info(log.str());
             }
 
             switch (eType) {

--- a/legacy/LegacyAmixerControl.hpp
+++ b/legacy/LegacyAmixerControl.hpp
@@ -45,7 +45,8 @@ public:
      */
     LegacyAmixerControl(const std::string &mappingValue,
                         CInstanceConfigurableElement *instanceConfigurableElement,
-                        const CMappingContext &context);
+                        const CMappingContext &context,
+                        core::log::ILogger& logger);
 
 protected:
     virtual bool accessHW(bool receive, std::string &error);

--- a/tinyalsa/Android.mk
+++ b/tinyalsa/Android.mk
@@ -64,5 +64,6 @@ LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE := libtinyalsa-subsystem
 LOCAL_MODULE_OWNER := intel
 
-include external/stlport/libstlport.mk
+LOCAL_CLANG := true
+include external/libcxx/libcxx.mk
 include $(BUILD_SHARED_LIBRARY)

--- a/tinyalsa/TinyAlsaCtlPortConfig.cpp
+++ b/tinyalsa/TinyAlsaCtlPortConfig.cpp
@@ -69,8 +69,9 @@ const AlsaCtlPortConfig::PortConfig TinyAlsaCtlPortConfig::_defaultPortConfig = 
 TinyAlsaCtlPortConfig::TinyAlsaCtlPortConfig(
     const std::string &mappingValue,
     CInstanceConfigurableElement *instanceConfigurableElement,
-    const CMappingContext &context)
-    : base(mappingValue, instanceConfigurableElement, context, _defaultPortConfig)
+    const CMappingContext &context,
+    core::log::ILogger& logger)
+    : base(mappingValue, instanceConfigurableElement, context, logger, _defaultPortConfig)
 {
     // Init stream handle array
     _streamHandle[Playback] = NULL;

--- a/tinyalsa/TinyAlsaCtlPortConfig.hpp
+++ b/tinyalsa/TinyAlsaCtlPortConfig.hpp
@@ -47,7 +47,8 @@ public:
      */
     TinyAlsaCtlPortConfig(const std::string &mappingValue,
                           CInstanceConfigurableElement *instanceConfigurableElement,
-                          const CMappingContext &context);
+                          const CMappingContext &context,
+                          core::log::ILogger& logger);
 
 protected:
     // Stream operations

--- a/tinyalsa/TinyAlsaSubsystem.cpp
+++ b/tinyalsa/TinyAlsaSubsystem.cpp
@@ -37,7 +37,8 @@
 #include "AmixerMutableVolume.hpp"
 #include <string>
 
-TinyAlsaSubsystem::TinyAlsaSubsystem(const std::string &name) : AlsaSubsystem(name), mMixers()
+TinyAlsaSubsystem::TinyAlsaSubsystem(const std::string &name, core::log::ILogger& logger) :
+    AlsaSubsystem(name, logger), mMixers()
 {
     // Provide creators to upper layer
     addSubsystemObjectFactory(

--- a/tinyalsa/TinyAlsaSubsystem.hpp
+++ b/tinyalsa/TinyAlsaSubsystem.hpp
@@ -38,7 +38,7 @@
 class TinyAlsaSubsystem : public AlsaSubsystem
 {
 public:
-    TinyAlsaSubsystem(const std::string &name);
+    TinyAlsaSubsystem(const std::string &name, core::log::ILogger& logger);
     ~TinyAlsaSubsystem();
 
     /**

--- a/tinyalsa/TinyAlsaSubsystemBuilder.cpp
+++ b/tinyalsa/TinyAlsaSubsystemBuilder.cpp
@@ -28,7 +28,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "SubsystemLibrary.h"
-#include "NamedElementBuilderTemplate.h"
+#include "LoggingElementBuilderTemplate.h"
 #include "TinyAlsaSubsystem.hpp"
 
 extern "C"
@@ -43,7 +43,7 @@ extern "C"
 void getTINYALSASubsystemBuilder(CSubsystemLibrary *subsystemLibrary)
 {
     subsystemLibrary->addElementBuilder(
-        "ALSA", new TNamedElementBuilderTemplate<TinyAlsaSubsystem>
+        "ALSA", new TLoggingElementBuilderTemplate<TinyAlsaSubsystem>(subsystemLibrary->getLogger())
         );
 }
 }

--- a/tinyalsa/TinyAmixerControl.cpp
+++ b/tinyalsa/TinyAmixerControl.cpp
@@ -31,7 +31,6 @@
 #include "TinyAlsaSubsystem.hpp"
 #include "InstanceConfigurableElement.h"
 #include "MappingContext.h"
-#include "AutoLog.h"
 #include <tinyalsa/asoundlib.h>
 #include <string>
 #include <string.h>
@@ -47,8 +46,9 @@ extern "C" void __gcov_flush();
 
 TinyAmixerControl::TinyAmixerControl(const std::string &mappingValue,
                                      CInstanceConfigurableElement *instanceConfigurableElement,
-                                     const CMappingContext &context)
-    : base(mappingValue, instanceConfigurableElement, context)
+                                     const CMappingContext &context,
+                                     core::log::ILogger& logger)
+    : base(mappingValue, instanceConfigurableElement, context, logger)
 {
 #ifdef __USE_GCOV__
     atexit(__gcov_flush);
@@ -57,8 +57,10 @@ TinyAmixerControl::TinyAmixerControl(const std::string &mappingValue,
 
 TinyAmixerControl::TinyAmixerControl(const std::string &mappingValue,
                                      CInstanceConfigurableElement *instanceConfigurableElement,
-                                     const CMappingContext &context, uint32_t scalarSize)
-    : base(mappingValue, instanceConfigurableElement, context, scalarSize)
+                                     const CMappingContext &context,
+                                     core::log::ILogger& logger,
+                                     uint32_t scalarSize)
+    : base(mappingValue, instanceConfigurableElement, context, logger, scalarSize)
 {
 }
 
@@ -69,8 +71,6 @@ uint32_t TinyAmixerControl::getNumValues(struct mixer_ctl *mixerControl)
 
 bool TinyAmixerControl::accessHW(bool receive, std::string &error)
 {
-    CAutoLog autoLog(getConfigurableElement(), "ALSA", isDebugEnabled());
-
     // Mixer handle
     struct mixer *mixer;
     // Mixer control handle

--- a/tinyalsa/TinyAmixerControl.hpp
+++ b/tinyalsa/TinyAmixerControl.hpp
@@ -48,7 +48,8 @@ public:
      */
     TinyAmixerControl(const std::string &mappingValue,
                       CInstanceConfigurableElement *instanceConfigurableElement,
-                      const CMappingContext &context);
+                      const CMappingContext &context,
+                      core::log::ILogger& logger);
 
     /**
      * TinyAMixerControl Class constructor
@@ -61,6 +62,7 @@ public:
     TinyAmixerControl(const std::string &mappingValue,
                       CInstanceConfigurableElement *instanceConfigurableElement,
                       const CMappingContext &context,
+                      core::log::ILogger& logger,
                       uint32_t scalarSize);
 
 protected:

--- a/tinyalsa/TinyAmixerControlArray.cpp
+++ b/tinyalsa/TinyAmixerControlArray.cpp
@@ -43,8 +43,9 @@
 TinyAmixerControlArray::TinyAmixerControlArray(
     const std::string &mappingValue,
     CInstanceConfigurableElement *instanceConfigurableElement,
-    const CMappingContext &context)
-    : base(mappingValue, instanceConfigurableElement, context, _byteScalarSize)
+    const CMappingContext &context,
+    core::log::ILogger& logger)
+    : base(mappingValue, instanceConfigurableElement, context, logger,  _byteScalarSize)
 {
 }
 
@@ -117,7 +118,7 @@ bool TinyAmixerControlArray::writeControl(struct mixer_ctl *mixerControl,
 
 void TinyAmixerControlArray::displayAndCleanString(std::stringstream &stringValue) const
 {
-    log_info("%s", stringValue.str().c_str());
+    _Logger.info(stringValue.str());
     stringValue.str(std::string());
 }
 

--- a/tinyalsa/TinyAmixerControlArray.hpp
+++ b/tinyalsa/TinyAmixerControlArray.hpp
@@ -47,7 +47,8 @@ public:
      */
     TinyAmixerControlArray(const std::string &mappingValue,
                            CInstanceConfigurableElement *instanceConfigurableElement,
-                           const CMappingContext &context);
+                           const CMappingContext &context,
+                           core::log::ILogger& logger);
 
 protected:
     virtual bool readControl(struct mixer_ctl *mixerControl,

--- a/tinyalsa/TinyAmixerControlValue.cpp
+++ b/tinyalsa/TinyAmixerControlValue.cpp
@@ -35,14 +35,16 @@
 #include <ctype.h>
 #include <errno.h>
 #include <string>
+#include <sstream>
 
 #define base TinyAmixerControl
 
 TinyAmixerControlValue::TinyAmixerControlValue(
     const std::string &mappingValue,
     CInstanceConfigurableElement *instanceConfigurableElement,
-    const CMappingContext &context)
-    : base(mappingValue, instanceConfigurableElement, context)
+    const CMappingContext &context,
+    core::log::ILogger& logger)
+    : base(mappingValue, instanceConfigurableElement, context, logger)
 {
 }
 
@@ -65,8 +67,10 @@ bool TinyAmixerControlValue::readControl(struct mixer_ctl *mixerControl,
 
         if (isDebugEnabled()) {
 
-            log_info("Reading alsa element %s, index %u with value %u",
-                     getControlName().c_str(), elementNumber, value);
+            std::ostringstream log;
+            log << "Reading alsa element " << getControlName() << ", index " << elementNumber
+                << " with value " << value;
+            _Logger.info(log.str());
         }
 
         toBlackboard(value);
@@ -91,8 +95,10 @@ bool TinyAmixerControlValue::writeControl(struct mixer_ctl *mixerControl,
 
         if (isDebugEnabled()) {
 
-            log_info("Writing alsa element %s, index %u with value %u",
-                     getControlName().c_str(), elementNumber, value);
+            std::ostringstream log;
+            log << "Writing alsa element " << getControlName() << ", index " << elementNumber
+                << " with value " << value;
+            _Logger.info(log.str());
         }
 
         // Write element

--- a/tinyalsa/TinyAmixerControlValue.hpp
+++ b/tinyalsa/TinyAmixerControlValue.hpp
@@ -47,7 +47,8 @@ public:
      */
     TinyAmixerControlValue(const std::string &mappingValue,
                            CInstanceConfigurableElement *instanceConfigurableElement,
-                           const CMappingContext &context);
+                           const CMappingContext &context,
+                           core::log::ILogger& logger);
 
 protected:
     virtual bool readControl(struct mixer_ctl *mixerControl,


### PR DESCRIPTION
In order to use C++11 in Android, we have to support clang compiler.
The core implements a new log API which is required for this support.