### PR TITLE
Link to shared library xmlSerializer

### DIFF
--- a/base/Android.mk
+++ b/base/Android.mk
@@ -37,9 +37,9 @@ LOCAL_SRC_FILES := \
     AlsaCtlPortConfig.cpp \
     AmixerControl.cpp \
 
-LOCAL_STATIC_LIBRARIES := \
-    libparameter_includes \
-    libxmlserializer_includes \
+LOCAL_SHARED_LIBRARIES := \
+    libparameter \
+    libxmlserializer
 
 LOCAL_CFLAGS := \
     -Wall \

--- a/legacy/Android.mk
+++ b/legacy/Android.mk
@@ -48,11 +48,10 @@ LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)
 LOCAL_SHARED_LIBRARIES := \
     libparameter \
     libasound \
+    libxmlserializer \
 
 LOCAL_STATIC_LIBRARIES := \
     libalsabase-subsystem \
-    libparameter_includes \
-    libxmlserializer_includes \
 
 # -D_POSIX_C_SOURCE=200809 is needed because alsa-lib is redefining
 # the timeval and timespec structures

--- a/tinyalsa/Android.mk
+++ b/tinyalsa/Android.mk
@@ -47,11 +47,10 @@ LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)
 LOCAL_SHARED_LIBRARIES := \
     libparameter \
     libtinyalsa \
+    libxmlserializer \
 
 LOCAL_STATIC_LIBRARIES := \
     libalsabase-subsystem \
-    libparameter_includes \
-    libxmlserializer_includes \
 
 LOCAL_CFLAGS += \
     -Wall \


### PR DESCRIPTION
The Parameter Framework has recently removed (this trick was not working on osx) its *_include libraries. They were used to include headers without linking against the libraries in the android build system.

There is two way to include headers from a library:
 - copy the headers (but that would be in contradiction with how the main pfw headers are included)
 - link against the library (chosen solution)

To avoid linking against a static libxmlserializer - ie add it and its dependency to all plugins - the xmlserializer library is now dynamic.

Link against the dynamic library xmlserializer and no longer use *_include.