### PR TITLE
Update to Parameter Framework 3.0 API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2014, Intel Corporation
+# Copyright (c) 2011-2015, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification,
@@ -31,23 +31,19 @@ cmake_minimum_required(VERSION 2.8)
 
 project(parameter-framework-plugins-alsa)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall -Wextra")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Werror -Wall -Wextra")
 
 #
 # Find PFW libraries and include directories
 #
-find_path(PFW_CORE_ROOT_DIR NAMES include/parameter/plugin/Subsystem.h)
+find_path(PFW_INCLUDE_ROOT NAMES parameter/plugin/Plugin.h)
 
-find_library(PFW_CORE_LIBRARY NAMES parameter
-    HINTS ${PFW_CORE_ROOT_DIR}/lib)
+find_library(PFW_CORE_LIBRARY NAMES parameter)
 
-find_path(PFW_CORE_INCLUDE_DIR NAMES Subsystem.h
-    HINTS ${PFW_CORE_ROOT_DIR}/include/parameter/plugin)
-find_path(PFW_XMLSERIALIZER_INCLUDE_DIR NAMES XmlSink.h
-    HINTS ${PFW_CORE_ROOT_DIR}/include/xmlserializer)
-
-set(PFW_INCLUDE_DIRS ${PFW_CORE_INCLUDE_DIR} ${PFW_XMLSERIALIZER_INCLUDE_DIR})
-set(PFW_LIBRARIES ${PFW_CORE_LIBRARY})
+set(PFW_INCLUDE_DIRS
+    ${PFW_INCLUDE_ROOT}/parameter/plugin
+    ${PFW_INCLUDE_ROOT}/xmlserializer
+    ${PFW_INCLUDE_ROOT}/utility)
 
 #
 # Find (regular) alsa-lib

--- a/base/AlsaCtlPortConfig.cpp
+++ b/base/AlsaCtlPortConfig.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -43,10 +43,12 @@ using std::string;
 AlsaCtlPortConfig::AlsaCtlPortConfig(const string &mappingValue,
                                      CInstanceConfigurableElement *instanceConfigurableElement,
                                      const CMappingContext &context,
+                                     core::log::Logger& logger,
                                      const PortConfig &defaultPortConfig)
     : base(mappingValue,
            instanceConfigurableElement,
-           context),
+           context,
+           logger),
       _device(context.getItemAsInteger(AlsaCtlDevice)),
       _portConfig(defaultPortConfig)
 {

--- a/base/AlsaCtlPortConfig.hpp
+++ b/base/AlsaCtlPortConfig.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -60,7 +60,8 @@ public:
 
     AlsaCtlPortConfig(const std::string &mappingValue,
                       CInstanceConfigurableElement *instanceConfigurableElement,
-                      const CMappingContext &context,
+                      const CMappingContext &contVext,
+                      core::log::Logger& logger,
                       const PortConfig &defaultPortConfig);
 
 protected:

--- a/base/AlsaSubsystem.hpp
+++ b/base/AlsaSubsystem.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -41,7 +41,7 @@
 class AlsaSubsystem : public CSubsystem
 {
 public:
-    AlsaSubsystem(const std::string &name) : CSubsystem(name)
+    AlsaSubsystem(const std::string &name, core::log::Logger& logger) : CSubsystem(name, logger)
     {
         // Provide mapping keys to upper layer
         addContextMappingKey("Card");

--- a/base/AlsaSubsystemObject.cpp
+++ b/base/AlsaSubsystemObject.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -30,6 +30,7 @@
 #include "AlsaSubsystemObject.hpp"
 #include "MappingContext.h"
 #include "AlsaMappingKeys.hpp"
+#include <convert.hpp>
 
 #include <limits.h>
 #include <unistd.h>
@@ -45,8 +46,9 @@ const char AlsaSubsystemObject::_soundCardPath[] = "/proc/asound/";
 
 AlsaSubsystemObject::AlsaSubsystemObject(const string &mappingValue,
                                          CInstanceConfigurableElement *instanceConfigurableElement,
-                                         const CMappingContext &context)
-    : base(instanceConfigurableElement, mappingValue),
+                                         const CMappingContext &context,
+                                         core::log::Logger& logger)
+    : base(instanceConfigurableElement, logger, mappingValue),
       _cardName(context.getItem(AlsaCard)),
       _cardIndex(getCardNumberByName(context.getItem(AlsaCard)))
 {
@@ -55,10 +57,11 @@ AlsaSubsystemObject::AlsaSubsystemObject(const string &mappingValue,
 
 AlsaSubsystemObject::AlsaSubsystemObject(const string &mappingValue,
                                          CInstanceConfigurableElement *instanceConfigurableElement,
+                                         core::log::Logger& logger,
                                          uint32_t firstAmendKey,
                                          uint32_t nbAmendKeys,
                                          const CMappingContext &context)
-    : base(instanceConfigurableElement, mappingValue, firstAmendKey, nbAmendKeys, context),
+    : base(instanceConfigurableElement, logger, mappingValue, firstAmendKey, nbAmendKeys, context),
       _cardName(context.getItem(AlsaCard)),
       _cardIndex(getCardNumberByName(context.getItem(AlsaCard)))
 {
@@ -89,6 +92,10 @@ int32_t AlsaSubsystemObject::getCardNumberByName(const string &cardName)
     }
 
     // Extract card number from link (Example: 5 from card5)
-    return asInteger(numberFilepath + strlen("card"));
+    int32_t cardNumber = 0;
+    if (convertTo(numberFilepath + strlen("card"), cardNumber)) {
+        return cardNumber;
+    }
 
+    return -1; // A negative value indicates a failure
 }

--- a/base/AlsaSubsystemObject.hpp
+++ b/base/AlsaSubsystemObject.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -42,9 +42,11 @@ class AlsaSubsystemObject : public CFormattedSubsystemObject
 public:
     AlsaSubsystemObject(const std::string &mappingValue,
                         CInstanceConfigurableElement *instanceConfigurableElement,
-                        const CMappingContext &context);
+                        const CMappingContext &context,
+                        core::log::Logger& logger);
     AlsaSubsystemObject(const std::string &strMappingValue,
                         CInstanceConfigurableElement *instanceConfigurableElement,
+                        core::log::Logger& logger,
                         uint32_t firstAmendKey,
                         uint32_t nbAmendKeys,
                         const CMappingContext &context);

--- a/base/AmixerControl.cpp
+++ b/base/AmixerControl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -35,7 +35,6 @@
 #include "ParameterBlockType.h"
 #include "MappingContext.h"
 #include "AlsaMappingKeys.hpp"
-#include "AutoLog.h"
 #include <string.h>
 #include <string>
 #include <ctype.h>
@@ -45,8 +44,9 @@
 
 AmixerControl::AmixerControl(const std::string &mappingValue,
                              CInstanceConfigurableElement *instanceConfigurableElement,
-                             const CMappingContext &context)
-    : base(mappingValue, instanceConfigurableElement,
+                             const CMappingContext &context,
+                             core::log::Logger& logger)
+    : base(mappingValue, instanceConfigurableElement, logger,
            AlsaAmend1,
            gNbAlsaAmends,
            context),
@@ -87,7 +87,7 @@ AmixerControl::AmixerControl(const std::string &mappingValue,
 
         // If the parameter is a scalar its array size is 0, not 1.
         _scalarSize = instanceConfigurableElement->getFootPrint() /
-                      std::max(parameterType->getArrayLength(), 1U);
+                      std::max(parameterType->getArrayLength(), size_t{1});
         break;
     }
     default: {
@@ -98,8 +98,10 @@ AmixerControl::AmixerControl(const std::string &mappingValue,
 
 AmixerControl::AmixerControl(const std::string &mappingValue,
                              CInstanceConfigurableElement *instanceConfigurableElement,
-                             const CMappingContext &context, uint32_t scalarSize)
-    : base(mappingValue, instanceConfigurableElement,
+                             const CMappingContext &context,
+                             core::log::Logger& logger,
+                             uint32_t scalarSize)
+    : base(mappingValue, instanceConfigurableElement, logger,
            AlsaAmend1,
            gNbAlsaAmends,
            context),
@@ -114,9 +116,9 @@ void AmixerControl::logControlInfo(bool receive) const
     if (_isDebugEnabled) {
 
         std::string controlName = getFormattedMappingValue();
-        log_info("%s ALSA Element Instance: %s\t\t(Control Element: %s)",
-                 receive ? "Reading" : "Writing",
-                 getConfigurableElement()->getPath().c_str(), controlName.c_str());
+        info() << (receive ? "Reading" : "Writing")
+               << " ALSA Element Instance: " << getConfigurableElement()->getPath()
+               << "\t\t(Control Element: " << controlName << ")";
     }
 }
 

--- a/base/AmixerControl.hpp
+++ b/base/AmixerControl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -52,7 +52,8 @@ public:
      */
     AmixerControl(const std::string &mappingValue,
                   CInstanceConfigurableElement *instanceConfigurableElement,
-                  const CMappingContext &context);
+                  const CMappingContext &context,
+                  core::log::Logger& logger);
 
     /**
      * AmixerControl Class constructor
@@ -64,7 +65,9 @@ public:
      */
     AmixerControl(const std::string &mappingValue,
                   CInstanceConfigurableElement *instanceConfigurableElement,
-                  const CMappingContext &context, uint32_t scalarSize);
+                  const CMappingContext &context,
+                  core::log::Logger& logger,
+                  uint32_t scalarSize);
 
 protected:
     virtual bool accessHW(bool receive, std::string &error) = 0;

--- a/base/AmixerMutableVolume.hpp
+++ b/base/AmixerMutableVolume.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -74,8 +74,9 @@ public:
      */
     AmixerMutableVolume(const std::string &mappingValue,
                         CInstanceConfigurableElement *instConfigElement,
-                        const CMappingContext &context)
-        : SubsystemObjectBase(mappingValue, instConfigElement, context),
+                        const CMappingContext &context,
+                        core::log::Logger& logger)
+        : SubsystemObjectBase(mappingValue, instConfigElement, context, logger),
           _volumeLevelConfigurableElement(NULL)
     {
         if ((instConfigElement->getType() == CInstanceConfigurableElement::EParameterBlock) &&

--- a/legacy/CMakeLists.txt
+++ b/legacy/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2014, Intel Corporation
+# Copyright (c) 2011-2015, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification,
@@ -40,6 +40,6 @@ include_directories(
 target_link_libraries(alsa-subsystem
     alsabase-subsystem
     ${ALSA_LIBRARIES}
-    ${PFW_LIBRARIES})
+    ${PFW_CORE_LIBRARY})
 
 install(TARGETS alsa-subsystem LIBRARY DESTINATION lib)

--- a/legacy/LegacyAlsaCtlPortConfig.cpp
+++ b/legacy/LegacyAlsaCtlPortConfig.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -49,8 +49,9 @@ const uint32_t LegacyAlsaCtlPortConfig::_latencyMicroSeconds = 500000;
 LegacyAlsaCtlPortConfig::LegacyAlsaCtlPortConfig(
     const std::string &mappingValue,
     CInstanceConfigurableElement *instanceConfigurableElement,
-    const CMappingContext &context)
-    :  base(mappingValue, instanceConfigurableElement, context, _defaultPortConfig)
+    const CMappingContext &context,
+    core::log::Logger& logger)
+    :  base(mappingValue, instanceConfigurableElement, context, logger, _defaultPortConfig)
 {
     // Init stream handle array
     _streamHandle[Playback] = NULL;

--- a/legacy/LegacyAlsaCtlPortConfig.hpp
+++ b/legacy/LegacyAlsaCtlPortConfig.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -47,7 +47,8 @@ public:
      */
     LegacyAlsaCtlPortConfig(const std::string &mappingValue,
                             CInstanceConfigurableElement *instanceConfigurableElement,
-                            const CMappingContext &context);
+                            const CMappingContext &context,
+                            core::log::Logger& logger);
 
 protected:
     // Stream operations

--- a/legacy/LegacyAlsaSubsystem.cpp
+++ b/legacy/LegacyAlsaSubsystem.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -36,7 +36,8 @@
 #include "AmixerMutableVolume.hpp"
 #include <string>
 
-LegacyAlsaSubsystem::LegacyAlsaSubsystem(const std::string &name) : AlsaSubsystem(name)
+LegacyAlsaSubsystem::LegacyAlsaSubsystem(const std::string &name, core::log::Logger& logger) :
+    AlsaSubsystem(name, logger)
 {
     // Provide creators to upper layer
     addSubsystemObjectFactory(

--- a/legacy/LegacyAlsaSubsystem.hpp
+++ b/legacy/LegacyAlsaSubsystem.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -36,5 +36,5 @@
 class LegacyAlsaSubsystem : public AlsaSubsystem
 {
 public:
-    LegacyAlsaSubsystem(const std::string &name);
+    LegacyAlsaSubsystem(const std::string &name, core::log::Logger& logger);
 };

--- a/legacy/LegacyAlsaSubsystemBuilder.cpp
+++ b/legacy/LegacyAlsaSubsystemBuilder.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -27,10 +27,9 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#include "SubsystemLibrary.h"
-#include "NamedElementBuilderTemplate.h"
+#include <Plugin.h>
+#include <LoggingElementBuilderTemplate.h>
 #include "LegacyAlsaSubsystem.hpp"
-#include "LegacyAmixerControl.hpp"
 
 extern "C"
 {
@@ -38,13 +37,11 @@ extern "C"
  * Alsa subsystem builder
  * This function is called when the PFW parses a subsystem structure XML of type "ALSA".
  * It will then create an Amixer Subsystem
- *
- * @param[in] subsystemLibrary the pointer on the subsystem library
  */
-void getALSASubsystemBuilder(CSubsystemLibrary *subsystemLibrary)
+void PARAMETER_FRAMEWORK_PLUGIN_ENTRYPOINT_V1(CSubsystemLibrary *subsystemLibrary,
+                                              core::log::Logger &logger)
 {
     subsystemLibrary->addElementBuilder(
-        "ALSA", new TNamedElementBuilderTemplate<LegacyAlsaSubsystem>
-        );
+        "ALSA", new TLoggingElementBuilderTemplate<LegacyAlsaSubsystem>(logger));
 }
 }

--- a/legacy/LegacyAmixerControl.hpp
+++ b/legacy/LegacyAmixerControl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -45,7 +45,8 @@ public:
      */
     LegacyAmixerControl(const std::string &mappingValue,
                         CInstanceConfigurableElement *instanceConfigurableElement,
-                        const CMappingContext &context);
+                        const CMappingContext &context,
+                        core::log::Logger& logger);
 
 protected:
     virtual bool accessHW(bool receive, std::string &error);

--- a/tinyalsa/TinyAlsaCtlPortConfig.cpp
+++ b/tinyalsa/TinyAlsaCtlPortConfig.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -69,8 +69,9 @@ const AlsaCtlPortConfig::PortConfig TinyAlsaCtlPortConfig::_defaultPortConfig = 
 TinyAlsaCtlPortConfig::TinyAlsaCtlPortConfig(
     const std::string &mappingValue,
     CInstanceConfigurableElement *instanceConfigurableElement,
-    const CMappingContext &context)
-    : base(mappingValue, instanceConfigurableElement, context, _defaultPortConfig)
+    const CMappingContext &context,
+    core::log::Logger& logger)
+    : base(mappingValue, instanceConfigurableElement, context, logger, _defaultPortConfig)
 {
     // Init stream handle array
     _streamHandle[Playback] = NULL;

--- a/tinyalsa/TinyAlsaCtlPortConfig.hpp
+++ b/tinyalsa/TinyAlsaCtlPortConfig.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -47,7 +47,8 @@ public:
      */
     TinyAlsaCtlPortConfig(const std::string &mappingValue,
                           CInstanceConfigurableElement *instanceConfigurableElement,
-                          const CMappingContext &context);
+                          const CMappingContext &context,
+                          core::log::Logger& logger);
 
 protected:
     // Stream operations

--- a/tinyalsa/TinyAlsaSubsystem.cpp
+++ b/tinyalsa/TinyAlsaSubsystem.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -37,7 +37,8 @@
 #include "AmixerMutableVolume.hpp"
 #include <string>
 
-TinyAlsaSubsystem::TinyAlsaSubsystem(const std::string &name) : AlsaSubsystem(name), mMixers()
+TinyAlsaSubsystem::TinyAlsaSubsystem(const std::string &name, core::log::Logger& logger) :
+    AlsaSubsystem(name, logger), mMixers()
 {
     // Provide creators to upper layer
     addSubsystemObjectFactory(

--- a/tinyalsa/TinyAlsaSubsystem.hpp
+++ b/tinyalsa/TinyAlsaSubsystem.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -38,7 +38,7 @@
 class TinyAlsaSubsystem : public AlsaSubsystem
 {
 public:
-    TinyAlsaSubsystem(const std::string &name);
+    TinyAlsaSubsystem(const std::string &name, core::log::Logger& logger);
     ~TinyAlsaSubsystem();
 
     /**

--- a/tinyalsa/TinyAlsaSubsystemBuilder.cpp
+++ b/tinyalsa/TinyAlsaSubsystemBuilder.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -27,8 +27,8 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#include "SubsystemLibrary.h"
-#include "NamedElementBuilderTemplate.h"
+#include <Plugin.h>
+#include <LoggingElementBuilderTemplate.h>
 #include "TinyAlsaSubsystem.hpp"
 
 extern "C"
@@ -37,13 +37,11 @@ extern "C"
  * TinyAmixer subsystem builder
  * This function is called when the PFW parses a subsystem structure XML of type "ALSA".
  * It will then create an TinyAMixer Subsystem
- *
- * @param[in] subsystemLibrary the pointer on the subsystem library
  */
-void getTINYALSASubsystemBuilder(CSubsystemLibrary *subsystemLibrary)
+void PARAMETER_FRAMEWORK_PLUGIN_ENTRYPOINT_V1(CSubsystemLibrary *subsystemLibrary,
+                                              core::log::Logger&)
 {
     subsystemLibrary->addElementBuilder(
-        "ALSA", new TNamedElementBuilderTemplate<TinyAlsaSubsystem>
-        );
+        "ALSA", new TLoggingElementBuilderTemplate<TinyAlsaSubsystem>(logger));
 }
 }

--- a/tinyalsa/TinyAmixerControl.cpp
+++ b/tinyalsa/TinyAmixerControl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -31,7 +31,6 @@
 #include "TinyAlsaSubsystem.hpp"
 #include "InstanceConfigurableElement.h"
 #include "MappingContext.h"
-#include "AutoLog.h"
 #include <tinyalsa/asoundlib.h>
 #include <string>
 #include <string.h>
@@ -47,8 +46,9 @@ extern "C" void __gcov_flush();
 
 TinyAmixerControl::TinyAmixerControl(const std::string &mappingValue,
                                      CInstanceConfigurableElement *instanceConfigurableElement,
-                                     const CMappingContext &context)
-    : base(mappingValue, instanceConfigurableElement, context)
+                                     const CMappingContext &context,
+                                     core::log::Logger& logger)
+    : base(mappingValue, instanceConfigurableElement, context, logger)
 {
 #ifdef __USE_GCOV__
     atexit(__gcov_flush);
@@ -57,8 +57,10 @@ TinyAmixerControl::TinyAmixerControl(const std::string &mappingValue,
 
 TinyAmixerControl::TinyAmixerControl(const std::string &mappingValue,
                                      CInstanceConfigurableElement *instanceConfigurableElement,
-                                     const CMappingContext &context, uint32_t scalarSize)
-    : base(mappingValue, instanceConfigurableElement, context, scalarSize)
+                                     const CMappingContext &context,
+                                     core::log::Logger& logger,
+                                     uint32_t scalarSize)
+    : base(mappingValue, instanceConfigurableElement, context, logger, scalarSize)
 {
 }
 
@@ -69,8 +71,6 @@ uint32_t TinyAmixerControl::getNumValues(struct mixer_ctl *mixerControl)
 
 bool TinyAmixerControl::accessHW(bool receive, std::string &error)
 {
-    CAutoLog autoLog(getConfigurableElement(), "ALSA", isDebugEnabled());
-
     // Mixer handle
     struct mixer *mixer;
     // Mixer control handle

--- a/tinyalsa/TinyAmixerControl.hpp
+++ b/tinyalsa/TinyAmixerControl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -48,7 +48,8 @@ public:
      */
     TinyAmixerControl(const std::string &mappingValue,
                       CInstanceConfigurableElement *instanceConfigurableElement,
-                      const CMappingContext &context);
+                      const CMappingContext &context,
+                      core::log::Logger& logger);
 
     /**
      * TinyAMixerControl Class constructor
@@ -61,6 +62,7 @@ public:
     TinyAmixerControl(const std::string &mappingValue,
                       CInstanceConfigurableElement *instanceConfigurableElement,
                       const CMappingContext &context,
+                      core::log::Logger& logger,
                       uint32_t scalarSize);
 
 protected:

--- a/tinyalsa/TinyAmixerControlArray.cpp
+++ b/tinyalsa/TinyAmixerControlArray.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -43,8 +43,9 @@
 TinyAmixerControlArray::TinyAmixerControlArray(
     const std::string &mappingValue,
     CInstanceConfigurableElement *instanceConfigurableElement,
-    const CMappingContext &context)
-    : base(mappingValue, instanceConfigurableElement, context, _byteScalarSize)
+    const CMappingContext &context,
+    core::log::Logger& logger)
+    : base(mappingValue, instanceConfigurableElement, context, logger,  _byteScalarSize)
 {
 }
 
@@ -117,7 +118,7 @@ bool TinyAmixerControlArray::writeControl(struct mixer_ctl *mixerControl,
 
 void TinyAmixerControlArray::displayAndCleanString(std::stringstream &stringValue) const
 {
-    log_info("%s", stringValue.str().c_str());
+    info() << stringValue.rdbuf();
     stringValue.str(std::string());
 }
 

--- a/tinyalsa/TinyAmixerControlArray.hpp
+++ b/tinyalsa/TinyAmixerControlArray.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -47,7 +47,8 @@ public:
      */
     TinyAmixerControlArray(const std::string &mappingValue,
                            CInstanceConfigurableElement *instanceConfigurableElement,
-                           const CMappingContext &context);
+                           const CMappingContext &context,
+                           core::log::Logger& logger);
 
 protected:
     virtual bool readControl(struct mixer_ctl *mixerControl,

--- a/tinyalsa/TinyAmixerControlValue.cpp
+++ b/tinyalsa/TinyAmixerControlValue.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -35,14 +35,16 @@
 #include <ctype.h>
 #include <errno.h>
 #include <string>
+#include <sstream>
 
 #define base TinyAmixerControl
 
 TinyAmixerControlValue::TinyAmixerControlValue(
     const std::string &mappingValue,
     CInstanceConfigurableElement *instanceConfigurableElement,
-    const CMappingContext &context)
-    : base(mappingValue, instanceConfigurableElement, context)
+    const CMappingContext &context,
+    core::log::Logger& logger)
+    : base(mappingValue, instanceConfigurableElement, context, logger)
 {
 }
 
@@ -65,8 +67,8 @@ bool TinyAmixerControlValue::readControl(struct mixer_ctl *mixerControl,
 
         if (isDebugEnabled()) {
 
-            log_info("Reading alsa element %s, index %u with value %u",
-                     getControlName().c_str(), elementNumber, value);
+            info() << "Reading alsa element " << getControlName()
+                   << ", index " << elementNumber << " with value " << value;
         }
 
         toBlackboard(value);
@@ -91,8 +93,8 @@ bool TinyAmixerControlValue::writeControl(struct mixer_ctl *mixerControl,
 
         if (isDebugEnabled()) {
 
-            log_info("Writing alsa element %s, index %u with value %u",
-                     getControlName().c_str(), elementNumber, value);
+            info() << "Writing alsa element " << getControlName()
+                   << ", index " << elementNumber << " with value " << value;
         }
 
         // Write element

--- a/tinyalsa/TinyAmixerControlValue.hpp
+++ b/tinyalsa/TinyAmixerControlValue.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -47,7 +47,8 @@ public:
      */
     TinyAmixerControlValue(const std::string &mappingValue,
                            CInstanceConfigurableElement *instanceConfigurableElement,
-                           const CMappingContext &context);
+                           const CMappingContext &context,
+                           core::log::Logger& logger);
 
 protected:
     virtual bool readControl(struct mixer_ctl *mixerControl,


### PR DESCRIPTION
PF 3.0 provides a new logging API and a new entry-point API.

It also makes it necessary to compile using C++11.

This patch update the filesystem plugin to let it compile against the new PF.