### PR TITLE
Initializing variable silence_size

### DIFF
--- a/tinyalsa/TinyAlsaCtlPortConfig.cpp
+++ b/tinyalsa/TinyAlsaCtlPortConfig.cpp
@@ -114,6 +114,7 @@ bool TinyAlsaCtlPortConfig::doOpenStream(StreamDirection streamDirection, std::s
     pcmConfig.start_threshold   = 0;
     pcmConfig.stop_threshold    = 0;
     pcmConfig.silence_threshold = 0;
+    pcmConfig.silence_size      = 0;
     pcmConfig.avail_min         = 0;
 
     // Open and configure


### PR DESCRIPTION
Coverity complains due a not initialized variable silence_size,
initializing to 0 to avoid problems with unitialized variable.

Signed-off-by: Francisco Mendez <francisco.mendez@intel.com>