### PR TITLE
Allow PFW to instanciate every kind of element on top of Bytes Control mixer

### DIFF
--- a/legacy/LegacyAmixerControl.cpp
+++ b/legacy/LegacyAmixerControl.cpp
@@ -150,6 +150,10 @@ bool LegacyAmixerControl::accessHW(bool receive, std::string &error)
     elementCount = snd_ctl_elem_info_get_count(info);
 
     uint32_t scalarSize = getScalarSize();
+    // For Bytes control force scalar size to 1 byte
+    if (eType == SND_CTL_ELEM_TYPE_BYTES) {
+        scalarSize = 1;
+    }
 
     // If size defined in the PFW different from alsa mixer control size, return an error
     if (elementCount * scalarSize != getSize()) {


### PR DESCRIPTION
PFW elements can be mapped on Bytes Control mixer.
In this case, the scalar size is the length of Bytes Control mixer.

Fix Alsa mixer length check. In cae of Bytes Control,
the mixer length is checked versus the element size.