### PR TITLE
Replace convertion functions

### DIFF
--- a/tinyalsa/TinyAlsaCtlPortConfig.cpp
+++ b/tinyalsa/TinyAlsaCtlPortConfig.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2015, Intel Corporation
+ * Copyright (c) 2011-2016, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -92,7 +92,7 @@ bool TinyAlsaCtlPortConfig::doOpenStream(StreamDirection streamDirection, std::s
     // Check Format is supported by the plugin
     if (portConfig.format >= pcmFormatTranslationTableSize) {
 
-        error = "The format n°" + asString(portConfig.format) +
+        error = "The format n°" + std::to_string(int{portConfig.format}) +
                 " is not supported by the TinyAlsa plugin";
         return false;
     }

--- a/tinyalsa/TinyAmixerControl.cpp
+++ b/tinyalsa/TinyAmixerControl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2015, Intel Corporation
+ * Copyright (c) 2011-2016, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -31,6 +31,7 @@
 #include "TinyAlsaSubsystem.hpp"
 #include "InstanceConfigurableElement.h"
 #include "MappingContext.h"
+#include <convert.hpp>
 #include <tinyalsa/asoundlib.h>
 #include <string>
 #include <string.h>
@@ -110,8 +111,9 @@ bool TinyAmixerControl::accessHW(bool receive, std::string &error)
 
     // Get control handle
     if (isdigit(controlName[0])) {
-
-        mixerControl = mixer_get_ctl(mixer, asInteger(controlName));
+        int32_t controlNumber = 0;
+        convertTo(controlName,controlNumber);
+        mixerControl = mixer_get_ctl(mixer, controlNumber);
     } else {
 
         mixerControl = mixer_get_ctl_by_name(mixer, controlName.c_str());
@@ -132,9 +134,9 @@ bool TinyAmixerControl::accessHW(bool receive, std::string &error)
     // Check available size
     if (elementCount * scalarSize != getSize()) {
 
-        error = "ALSA: Control element count (" + asString(elementCount) +
+        error = "ALSA: Control element count (" + std::to_string(elementCount) +
                 ") and configurable scalar element count (" +
-                asString(getSize() / scalarSize) + ") mismatch";
+                std::to_string((getSize() / scalarSize)) + ") mismatch";
 
         return false;
     }


### PR DESCRIPTION
In the new PFW-3.2.3 release the convert functions asInteger()
and asString() are no more used.

So replace them by to_string() and convertTo().

Signed-off-by: Khaled Ben Amor <khaledx.ben.amor@intel.com>
