### PR TITLE
Fix compilation error when using CLANG

### DIFF
--- a/base/AlsaCtlPortConfig.cpp
+++ b/base/AlsaCtlPortConfig.cpp
@@ -55,7 +55,7 @@ AlsaCtlPortConfig::AlsaCtlPortConfig(const string &mappingValue,
 
 }
 
-bool AlsaCtlPortConfig::receiveFromHW(string &error)
+bool AlsaCtlPortConfig::receiveFromHW(string &/*error*/)
 {
     blackboardWrite(&_portConfig, sizeof(_portConfig));
 


### PR DESCRIPTION
"error" parameter is not used and causes unused parameter
error with CLANG.

Signed-off-by: Khaled Ben Amor <khaledx.ben.amor@intel.com>